### PR TITLE
replace deprecated SHA1_* functions with EVP_Digest* functions

### DIFF
--- a/stressdrive.c
+++ b/stressdrive.c
@@ -115,8 +115,8 @@ void PROGRESS_Finish(PROGRESS_CTX *ctx, uint32_t blockSize) {
 }
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-#  define EVP_MD_CTX_new   EVP_MD_CTX_create
-#  define EVP_MD_CTX_free  EVP_MD_CTX_destroy
+#define EVP_MD_CTX_new EVP_MD_CTX_create
+#define EVP_MD_CTX_free EVP_MD_CTX_destroy
 #endif
 
 void DIGEST_Init(EVP_MD_CTX *digestContext) {
@@ -286,9 +286,10 @@ int main(int argc, const char *argv[]) {
         PROGRESS_Update(&progress, blockIndex, blockSize);
 
         if ((blockIndex + bufferBlocks) % checkFrequency == 0) {
-          uint64_t checkIndex = blockIndex / checkFrequency;
-          DIGEST_Final(digestContext, checkDigests + checkIndex * SHA_DIGEST_LENGTH);
-          DIGEST_Init(digestContext);
+            uint64_t checkIndex = blockIndex / checkFrequency;
+            DIGEST_Final(digestContext,
+                         checkDigests + checkIndex * SHA_DIGEST_LENGTH);
+            DIGEST_Init(digestContext);
         }
     }
     PROGRESS_Finish(&progress, blockSize);
@@ -322,15 +323,17 @@ int main(int argc, const char *argv[]) {
         PROGRESS_Update(&progress, blockIndex, blockSize);
 
         if ((blockIndex + bufferBlocks) % checkFrequency == 0) {
-          uint64_t checkIndex = blockIndex / checkFrequency;
-          DIGEST_Final(digestContext, readShaDigest);
-          DIGEST_Init(digestContext);
-          if (bcmp(checkDigests + checkIndex * SHA_DIGEST_LENGTH, readShaDigest, SHA_DIGEST_LENGTH) != 0) {
-            printf("\nFailed intermediate checksum for bytes %" PRIu64 "...%" PRIu64 "\n",
-                   (blockIndex + bufferBlocks - checkFrequency) * blockSize,
-                   blockIndex * blockSize + size);
-            exitCode = EXIT_FAILURE;
-          }
+            uint64_t checkIndex = blockIndex / checkFrequency;
+            DIGEST_Final(digestContext, readShaDigest);
+            DIGEST_Init(digestContext);
+            if (bcmp(checkDigests + checkIndex * SHA_DIGEST_LENGTH,
+                     readShaDigest, SHA_DIGEST_LENGTH) != 0) {
+                printf("\nFailed intermediate checksum for bytes %" PRIu64
+                       "...%" PRIu64 "\n",
+                       (blockIndex + bufferBlocks - checkFrequency) * blockSize,
+                       blockIndex * blockSize + size);
+                exitCode = EXIT_FAILURE;
+            }
         }
     }
     PROGRESS_Finish(&progress, blockSize);
@@ -338,7 +341,8 @@ int main(int argc, const char *argv[]) {
     DIGEST_Print(readShaDigest, "read");
     EVP_MD_CTX_free(digestContext);
 
-    if (exitCode == EXIT_SUCCESS && bcmp(writtenShaDigest, readShaDigest, SHA_DIGEST_LENGTH) == 0) {
+    if (exitCode == EXIT_SUCCESS &&
+        bcmp(writtenShaDigest, readShaDigest, SHA_DIGEST_LENGTH) == 0) {
         printf("SUCCESS\n");
     } else {
         printf("FAILURE\n");

--- a/stressdrive.c
+++ b/stressdrive.c
@@ -114,8 +114,33 @@ void PROGRESS_Finish(PROGRESS_CTX *ctx, uint32_t blockSize) {
     printf("\n");
 }
 
-void SHA1_Finish(unsigned char *digest, SHA_CTX *ctx, const char *name) {
-    SHA1_Final(digest, ctx);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#  define EVP_MD_CTX_new   EVP_MD_CTX_create
+#  define EVP_MD_CTX_free  EVP_MD_CTX_destroy
+#endif
+
+void DIGEST_Init(EVP_MD_CTX *digestContext) {
+    if (1 != EVP_DigestInit_ex(digestContext, EVP_sha1(), NULL)) {
+        fprintf(stderr, "Digest initialisation failed\n");
+        exit(EXIT_CALL_FAILED);
+    }
+}
+
+void DIGEST_Update(EVP_MD_CTX *digestContext, const void *d, size_t cnt) {
+    if (1 != EVP_DigestUpdate(digestContext, d, cnt)) {
+        fprintf(stderr, "Digest update failed\n");
+        exit(EXIT_CALL_FAILED);
+    }
+}
+
+void DIGEST_Final(EVP_MD_CTX *digestContext, unsigned char *digest) {
+    if (1 != EVP_DigestFinal_ex(digestContext, digest, NULL)) {
+        fprintf(stderr, "Digest finalisation failed\n");
+        exit(EXIT_CALL_FAILED);
+    }
+}
+
+void DIGEST_Print(unsigned char *digest, const char *name) {
     for (size_t i = 0; i < SHA_DIGEST_LENGTH; i++) {
         printf("%02x", digest[i]);
     }
@@ -199,7 +224,12 @@ int main(int argc, const char *argv[]) {
     }
 #endif
 
-    SHA_CTX shaContext;
+    EVP_MD_CTX *digestContext;
+    if ((digestContext = EVP_MD_CTX_new()) == NULL) {
+        fprintf(stderr, "Digest context creation failed\n");
+        exit(EXIT_CALL_FAILED);
+    }
+
     PROGRESS_CTX progress;
 
     int aesKeylength = 128;
@@ -229,7 +259,7 @@ int main(int argc, const char *argv[]) {
     memset(aesInput, 0, bufferSize);
 
     printf("writing random data to %s\n", drivePath);
-    SHA1_Init(&shaContext);
+    DIGEST_Init(digestContext);
     PROGRESS_Init(&progress, blockCount, "writing");
     for (uint64_t blockIndex = 0; blockIndex < blockCount;
          blockIndex += bufferBlocks) {
@@ -252,20 +282,21 @@ int main(int argc, const char *argv[]) {
             perror("write() failed");
             exit(EXIT_CALL_FAILED);
         }
-        SHA1_Update(&shaContext, buffer, size);
+        DIGEST_Update(digestContext, buffer, size);
         PROGRESS_Update(&progress, blockIndex, blockSize);
 
         if ((blockIndex + bufferBlocks) % checkFrequency == 0) {
           uint64_t checkIndex = blockIndex / checkFrequency;
-          SHA1_Final(checkDigests + checkIndex * SHA_DIGEST_LENGTH, &shaContext);
-          SHA1_Init(&shaContext);
+          DIGEST_Final(digestContext, checkDigests + checkIndex * SHA_DIGEST_LENGTH);
+          DIGEST_Init(digestContext);
         }
     }
     PROGRESS_Finish(&progress, blockSize);
     EVP_CIPHER_CTX_free(aes);
 
     uint8_t writtenShaDigest[SHA_DIGEST_LENGTH];
-    SHA1_Finish(writtenShaDigest, &shaContext, "written");
+    DIGEST_Final(digestContext, writtenShaDigest);
+    DIGEST_Print(writtenShaDigest, "written");
 
     if (lseek(fd, 0LL, SEEK_SET) != 0LL) {
         perror("lseek() failed");
@@ -276,7 +307,7 @@ int main(int argc, const char *argv[]) {
     uint8_t readShaDigest[SHA_DIGEST_LENGTH];
 
     printf("verifying written data\n");
-    SHA1_Init(&shaContext);
+    DIGEST_Init(digestContext);
     PROGRESS_Init(&progress, blockCount, "reading");
     for (uint64_t blockIndex = 0; blockIndex < blockCount;
          blockIndex += bufferBlocks) {
@@ -287,13 +318,13 @@ int main(int argc, const char *argv[]) {
             perror("read() failed");
             exit(EXIT_CALL_FAILED);
         }
-        SHA1_Update(&shaContext, buffer, size);
+        DIGEST_Update(digestContext, buffer, size);
         PROGRESS_Update(&progress, blockIndex, blockSize);
 
         if ((blockIndex + bufferBlocks) % checkFrequency == 0) {
           uint64_t checkIndex = blockIndex / checkFrequency;
-          SHA1_Final(readShaDigest, &shaContext);
-          SHA1_Init(&shaContext);
+          DIGEST_Final(digestContext, readShaDigest);
+          DIGEST_Init(digestContext);
           if (bcmp(checkDigests + checkIndex * SHA_DIGEST_LENGTH, readShaDigest, SHA_DIGEST_LENGTH) != 0) {
             printf("\nFailed intermediate checksum for bytes %" PRIu64 "...%" PRIu64 "\n",
                    (blockIndex + bufferBlocks - checkFrequency) * blockSize,
@@ -303,7 +334,9 @@ int main(int argc, const char *argv[]) {
         }
     }
     PROGRESS_Finish(&progress, blockSize);
-    SHA1_Finish(readShaDigest, &shaContext, "read");
+    DIGEST_Final(digestContext, readShaDigest);
+    DIGEST_Print(readShaDigest, "read");
+    EVP_MD_CTX_free(digestContext);
 
     if (exitCode == EXIT_SUCCESS && bcmp(writtenShaDigest, readShaDigest, SHA_DIGEST_LENGTH) == 0) {
         printf("SUCCESS\n");


### PR DESCRIPTION
Deprecation is since openssl3 and the code works for versions 1.0, 1.1 and 3