### PR TITLE
Display digest list root for data written and read

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,12 @@ jobs:
         head -c $(( 256 * 1024 * 1024 )) ram_disk > 256M
         ! ./test_entropy 256M
     - name: run stressdrive on ram disk
+      shell: bash -eo pipefail {0}
       run: |
-        ./stressdrive ram_disk
+        ./stressdrive ram_disk | tee output
+    - name: check the hash list checksum
+      run: |
+        grep $(./hash_list_checksum ram_disk) output
     - name: test ram disk entropy when filled with random data
       run: |
         head -c $(( 256 * 1024 * 1024 )) ram_disk > 256M

--- a/hash_list_checksum
+++ b/hash_list_checksum
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+# encoding: ASCII-8BIT
+
+require 'digest'
+
+BLOCK_SIZE = 2**30 # 1GB
+CHUNK_SIZE = 2**15 # 32KB
+
+abort 'Expected one path to checksum' unless ARGV.length == 1
+
+root_digest = Digest::SHA1.new
+File.open(ARGV.first, 'rb') do |f|
+  buf = ''
+  until f.eof?
+    block_digest = Digest::SHA1.new
+    (BLOCK_SIZE / CHUNK_SIZE).times do
+      break unless f.read(CHUNK_SIZE, buf)
+
+      block_digest.update(buf)
+    end
+    root_digest.update(block_digest.digest)
+  end
+end
+puts root_digest.hexdigest

--- a/stressdrive.c
+++ b/stressdrive.c
@@ -147,7 +147,7 @@ void DIGEST_Print(unsigned char *digest, const char *name) {
     for (size_t i = 0; i < HASH_DIGEST_LENGTH; i++) {
         printf("%02x", digest[i]);
     }
-    printf(" <= hash digest of %s data\n", name);
+    printf(" <= root hash digest of %s data\n", name);
 }
 
 int main(int argc, const char *argv[]) {
@@ -208,7 +208,7 @@ int main(int argc, const char *argv[]) {
 
     uint16_t bufferBlocks = bufferSize / blockSize;
     uint32_t checkFrequency = 1024 * 1024 * 1024 / blockSize;
-    uint64_t checkCount = (blockCount + bufferBlocks - 1) / checkFrequency;
+    uint64_t checkCount = (blockCount + checkFrequency - 1) / checkFrequency;
     uint8_t *checkDigests = malloc(checkCount * HASH_DIGEST_LENGTH);
     if (checkDigests == NULL) {
         perror("malloc() failed");
@@ -227,8 +227,9 @@ int main(int argc, const char *argv[]) {
     }
 #endif
 
-    EVP_MD_CTX *digestContext;
-    if ((digestContext = EVP_MD_CTX_new()) == NULL) {
+    EVP_MD_CTX *digestContext, *rootDigestContext;
+    if ((digestContext = EVP_MD_CTX_new()) == NULL ||
+        (rootDigestContext = EVP_MD_CTX_new()) == NULL) {
         fprintf(stderr, "Digest context creation failed\n");
         exit(EXIT_CALL_FAILED);
     }
@@ -288,18 +289,24 @@ int main(int argc, const char *argv[]) {
         DIGEST_Update(digestContext, buffer, size);
         PROGRESS_Update(&progress, blockIndex, blockSize);
 
-        if ((blockIndex + bufferBlocks) % checkFrequency == 0) {
+        uint64_t hashedBlocks = blockIndex + bufferBlocks;
+        if (hashedBlocks % checkFrequency == 0 || hashedBlocks >= blockCount) {
             uint64_t checkIndex = blockIndex / checkFrequency;
             DIGEST_Final(digestContext,
                          checkDigests + checkIndex * HASH_DIGEST_LENGTH);
-            DIGEST_Init(digestContext);
+            if (hashedBlocks < blockCount) {
+                DIGEST_Init(digestContext);
+            }
         }
     }
     PROGRESS_Finish(&progress, blockSize);
     EVP_CIPHER_CTX_free(aes);
 
     uint8_t writtenHashDigest[HASH_DIGEST_LENGTH];
-    DIGEST_Final(digestContext, writtenHashDigest);
+    DIGEST_Init(rootDigestContext);
+    DIGEST_Update(rootDigestContext, checkDigests,
+                  checkCount * HASH_DIGEST_LENGTH);
+    DIGEST_Final(rootDigestContext, writtenHashDigest);
     DIGEST_Print(writtenHashDigest, "written");
 
     if (lseek(fd, 0LL, SEEK_SET) != 0LL) {
@@ -312,6 +319,7 @@ int main(int argc, const char *argv[]) {
 
     printf("verifying written data\n");
     DIGEST_Init(digestContext);
+    DIGEST_Init(rootDigestContext);
     PROGRESS_Init(&progress, blockCount, "reading");
     for (uint64_t blockIndex = 0; blockIndex < blockCount;
          blockIndex += bufferBlocks) {
@@ -325,10 +333,12 @@ int main(int argc, const char *argv[]) {
         DIGEST_Update(digestContext, buffer, size);
         PROGRESS_Update(&progress, blockIndex, blockSize);
 
-        if ((blockIndex + bufferBlocks) % checkFrequency == 0) {
+        uint64_t hashedBlocks = blockIndex + bufferBlocks;
+        if (hashedBlocks % checkFrequency == 0 || hashedBlocks >= blockCount) {
             uint64_t checkIndex = blockIndex / checkFrequency;
             DIGEST_Final(digestContext, readHashDigest);
-            DIGEST_Init(digestContext);
+            DIGEST_Update(rootDigestContext, readHashDigest,
+                          HASH_DIGEST_LENGTH);
             if (bcmp(checkDigests + checkIndex * HASH_DIGEST_LENGTH,
                      readHashDigest, HASH_DIGEST_LENGTH) != 0) {
                 printf("\nFailed intermediate checksum for bytes %" PRIu64
@@ -337,12 +347,16 @@ int main(int argc, const char *argv[]) {
                        blockIndex * blockSize + size);
                 exitCode = EXIT_FAILURE;
             }
+            if (hashedBlocks < blockCount) {
+                DIGEST_Init(digestContext);
+            }
         }
     }
     PROGRESS_Finish(&progress, blockSize);
-    DIGEST_Final(digestContext, readHashDigest);
+    DIGEST_Final(rootDigestContext, readHashDigest);
     DIGEST_Print(readHashDigest, "read");
     EVP_MD_CTX_free(digestContext);
+    EVP_MD_CTX_free(rootDigestContext);
 
     if (exitCode == EXIT_SUCCESS &&
         bcmp(writtenHashDigest, readHashDigest, HASH_DIGEST_LENGTH) == 0) {

--- a/stressdrive.c
+++ b/stressdrive.c
@@ -30,6 +30,9 @@
 #include <linux/fs.h>
 #endif
 
+#define HASH_DIGEST_LENGTH SHA_DIGEST_LENGTH
+#define HASH_INIT_FUNCTION EVP_sha1
+
 #define EXIT_CALL_FAILED 2
 
 #define MAX(a, b)                                                              \
@@ -120,7 +123,7 @@ void PROGRESS_Finish(PROGRESS_CTX *ctx, uint32_t blockSize) {
 #endif
 
 void DIGEST_Init(EVP_MD_CTX *digestContext) {
-    if (1 != EVP_DigestInit_ex(digestContext, EVP_sha1(), NULL)) {
+    if (1 != EVP_DigestInit_ex(digestContext, HASH_INIT_FUNCTION(), NULL)) {
         fprintf(stderr, "Digest initialisation failed\n");
         exit(EXIT_CALL_FAILED);
     }
@@ -141,10 +144,10 @@ void DIGEST_Final(EVP_MD_CTX *digestContext, unsigned char *digest) {
 }
 
 void DIGEST_Print(unsigned char *digest, const char *name) {
-    for (size_t i = 0; i < SHA_DIGEST_LENGTH; i++) {
+    for (size_t i = 0; i < HASH_DIGEST_LENGTH; i++) {
         printf("%02x", digest[i]);
     }
-    printf(" <= SHA-1 of %s data\n", name);
+    printf(" <= hash digest of %s data\n", name);
 }
 
 int main(int argc, const char *argv[]) {
@@ -206,7 +209,7 @@ int main(int argc, const char *argv[]) {
     uint16_t bufferBlocks = bufferSize / blockSize;
     uint32_t checkFrequency = 1024 * 1024 * 1024 / blockSize;
     uint64_t checkCount = (blockCount + bufferBlocks - 1) / checkFrequency;
-    uint8_t *checkDigests = malloc(checkCount * SHA_DIGEST_LENGTH);
+    uint8_t *checkDigests = malloc(checkCount * HASH_DIGEST_LENGTH);
     if (checkDigests == NULL) {
         perror("malloc() failed");
         exit(EXIT_CALL_FAILED);
@@ -288,16 +291,16 @@ int main(int argc, const char *argv[]) {
         if ((blockIndex + bufferBlocks) % checkFrequency == 0) {
             uint64_t checkIndex = blockIndex / checkFrequency;
             DIGEST_Final(digestContext,
-                         checkDigests + checkIndex * SHA_DIGEST_LENGTH);
+                         checkDigests + checkIndex * HASH_DIGEST_LENGTH);
             DIGEST_Init(digestContext);
         }
     }
     PROGRESS_Finish(&progress, blockSize);
     EVP_CIPHER_CTX_free(aes);
 
-    uint8_t writtenShaDigest[SHA_DIGEST_LENGTH];
-    DIGEST_Final(digestContext, writtenShaDigest);
-    DIGEST_Print(writtenShaDigest, "written");
+    uint8_t writtenHashDigest[HASH_DIGEST_LENGTH];
+    DIGEST_Final(digestContext, writtenHashDigest);
+    DIGEST_Print(writtenHashDigest, "written");
 
     if (lseek(fd, 0LL, SEEK_SET) != 0LL) {
         perror("lseek() failed");
@@ -305,7 +308,7 @@ int main(int argc, const char *argv[]) {
     }
 
     int exitCode = EXIT_SUCCESS;
-    uint8_t readShaDigest[SHA_DIGEST_LENGTH];
+    uint8_t readHashDigest[HASH_DIGEST_LENGTH];
 
     printf("verifying written data\n");
     DIGEST_Init(digestContext);
@@ -324,10 +327,10 @@ int main(int argc, const char *argv[]) {
 
         if ((blockIndex + bufferBlocks) % checkFrequency == 0) {
             uint64_t checkIndex = blockIndex / checkFrequency;
-            DIGEST_Final(digestContext, readShaDigest);
+            DIGEST_Final(digestContext, readHashDigest);
             DIGEST_Init(digestContext);
-            if (bcmp(checkDigests + checkIndex * SHA_DIGEST_LENGTH,
-                     readShaDigest, SHA_DIGEST_LENGTH) != 0) {
+            if (bcmp(checkDigests + checkIndex * HASH_DIGEST_LENGTH,
+                     readHashDigest, HASH_DIGEST_LENGTH) != 0) {
                 printf("\nFailed intermediate checksum for bytes %" PRIu64
                        "...%" PRIu64 "\n",
                        (blockIndex + bufferBlocks - checkFrequency) * blockSize,
@@ -337,12 +340,12 @@ int main(int argc, const char *argv[]) {
         }
     }
     PROGRESS_Finish(&progress, blockSize);
-    DIGEST_Final(digestContext, readShaDigest);
-    DIGEST_Print(readShaDigest, "read");
+    DIGEST_Final(digestContext, readHashDigest);
+    DIGEST_Print(readHashDigest, "read");
     EVP_MD_CTX_free(digestContext);
 
     if (exitCode == EXIT_SUCCESS &&
-        bcmp(writtenShaDigest, readShaDigest, SHA_DIGEST_LENGTH) == 0) {
+        bcmp(writtenHashDigest, readHashDigest, HASH_DIGEST_LENGTH) == 0) {
         printf("SUCCESS\n");
     } else {
         printf("FAILURE\n");


### PR DESCRIPTION
I noticed that stressdrive outputs sha1 of empty data (da39a3ee5e6b4b0d3255bfef95601890afd80709) for written and read data, which made me realise that it printed the digest only for the last 1GB chunk, which was of zero size if disk size is divisible by 1GB. There are few possibilities to deal with it if keeping the check for intermediate chunks:
* calculate digest of complete data in parallel, but that would be doubling CPU work with the only gain of having a simple sha1 of written data
* copy digest instead of finalising it after every intermediate chunk, but that would make it possible to know only the first chunk for which the digest didn't match as all following will be affected by wrong data in that chunk, not very big but still a minus
* use a [hash list](https://en.wikipedia.org/wiki/Hash_list), so digest of digests of intermediate chunks, which I went with.  `hash_list_checksum` contains ruby version of hash list and is used to recheck what stressdrive does